### PR TITLE
Add support for statically evaluated gem version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ This enables workflows like:
 > [!WARNING]
 > All the code found after the directive is passed directly to `Kernel.eval`. Use with caution.
 
+Another situation this cop might be useful in is checking gem version.
+
+You can achieve it by using a special form of the magic comment:
+
+```ruby
+# wait-for gem-version rails '>= 8.1'
+```
+
+This condition evaluates to `true` when the detected Rails version is at least `8.1`.
+
+Note that gem versions are determined statically using RuboCop’s [built-in feature](https://docs.rubocop.org/rubocop/development.html#limit-by-ruby-or-gem-versions).
+
+You can also use multiple version requirements:
+
+```ruby
+# wait-for gem-version rails '>= 8.1' '< 8.4'
+```
+
+
 ### Caveats
 
 1. Missing dependencies
@@ -82,8 +101,8 @@ This enables workflows like:
    RuboCop does not automatically load project dependencies from your `Gemfile.lock`. If your condition relies on gems like Rails, you may need to require them manually:
 
    ```ruby
-   # wait-for require 'rails/gem_version'; Rails.gem_version >= Gem::Version.new('9.0.0')
-   some_code_to_remove_once_rails90_is_in_use()
+   # wait for require 'rails'; defined?(::Rails.some_new_feature) != nil
+   some_code_to_remove_once_new_rails_feature_is_available()
    ```
 
 2. Caching

--- a/spec/rubocop/cop/wait_for/condition_met_spec.rb
+++ b/spec/rubocop/cop/wait_for/condition_met_spec.rb
@@ -52,6 +52,39 @@ RSpec.describe RuboCop::Cop::WaitFor::ConditionMet, :config do
           .with(/RuboCop::Cop::WaitFor::ConditionMet: Encountered exception during evaluating condition/)
           .once
       end
+
+      context 'with gem version condition' do
+        before do
+          allow(config).to receive(:gem_versions_in_target)
+            .and_return({ 'rails' => Gem::Version.new('3.4') })
+        end
+
+        it 'registers an offense when condition holds' do
+          expect_offense(<<~RUBY, directive: directive)
+            # %{directive} gem-version rails '>= 3.2'
+            ^^^{directive}^^^^^^^^^^^^^^^^^^^^^^^^^^^ Condition has been met.
+          RUBY
+        end
+
+        it 'does not register an offense when condition does not hold' do
+          expect_no_offenses(<<~RUBY)
+            # %{directive} gem-version rails '>= 3.5'
+          RUBY
+        end
+
+        it 'registers an offense when complex condition holds' do
+          expect_offense(<<~RUBY, directive: directive)
+            # %{directive} gem-version rails '>= 3.2' '< 3.6'
+            ^^^{directive}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Condition has been met.
+          RUBY
+        end
+
+        it 'does not register an offense when complex condition does not hold' do
+          expect_no_offenses(<<~RUBY)
+            # %{directive} gem-version rails '>= 3.0' '< 3.4'
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Support for this syntax

```ruby
wait-for gem-version rails '>= 7.1'
```

has been added.