### PR TITLE
Add support for `ruby-version` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add support for `# wait-for ruby-version <version-specification>` syntax to check Ruby version statically.
+
 ## [0.2.1] - 2025:08-20
 
 - Fix `config/default.yml` configuration. [#6](https://github.com/viralpraxis/rubocop-wait_for/pull/6)

--- a/README.md
+++ b/README.md
@@ -85,12 +85,19 @@ You can achieve it by using a special form of the magic comment:
 
 This condition evaluates to `true` when the detected Rails version is at least `8.1`.
 
+Also, you can do the same with Ruby version using the `ruby-version` syntax:
+
+```ruby
+# wait-for ruby-version '> 3.4'
+```
+
 Note that gem versions are determined statically using RuboCop’s [built-in feature](https://docs.rubocop.org/rubocop/development.html#limit-by-ruby-or-gem-versions).
 
 You can also use multiple version requirements:
 
 ```ruby
 # wait-for gem-version rails '>= 8.1' '< 8.4'
+# wait-for ruby-version '>= 3.4' '< 3.4.6'
 ```
 
 ### Caveats

--- a/spec/rubocop/cop/wait_for/condition_met_spec.rb
+++ b/spec/rubocop/cop/wait_for/condition_met_spec.rb
@@ -85,6 +85,46 @@ RSpec.describe RuboCop::Cop::WaitFor::ConditionMet, :config do
           RUBY
         end
       end
+
+      context 'with Ruby version condition' do
+        before do
+          allow(config).to receive(:target_ruby_version)
+            .and_return(Gem::Version.new('3.4.5'))
+        end
+
+        it 'registers an offense when condition holds' do
+          expect_offense(<<~RUBY, directive: directive)
+            # %{directive} ruby-version '>= 3.4'
+            ^^^{directive}^^^^^^^^^^^^^^^^^^^^^^ Condition has been met.
+          RUBY
+        end
+
+        it 'registers an offense when condition using only major version holds' do
+          expect_offense(<<~RUBY, directive: directive)
+            # %{directive} ruby-version '>= 3'
+            ^^^{directive}^^^^^^^^^^^^^^^^^^^^ Condition has been met.
+          RUBY
+        end
+
+        it 'does not register an offense when condition does not hold' do
+          expect_no_offenses(<<~RUBY)
+            # %{directive} ruby-version '>= 3.5'
+          RUBY
+        end
+
+        it 'registers an offense when complex condition holds' do
+          expect_offense(<<~RUBY, directive: directive)
+            # %{directive} ruby-version '>= 3.4' '< 3.6'
+            ^^^{directive}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Condition has been met.
+          RUBY
+        end
+
+        it 'does not register an offense when complex condition does not hold' do
+          expect_no_offenses(<<~RUBY)
+            # %{directive} ruby-version '>= 3.5' '< 3.6'
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We can now use this shorthand:

```ruby
# wait-for ruby-version '>= 3.4'
```